### PR TITLE
Add support for printing and accessing fields of rust enums

### DIFF
--- a/gdb/expprint.c
+++ b/gdb/expprint.c
@@ -368,6 +368,13 @@ print_subexp_standard (struct expression *exp, int *pos,
       fputs_filtered (&exp->elts[pc + 2].string, stream);
       return;
 
+    case STRUCTOP_ANONYMOUS:
+      tem = longest_to_int (exp->elts[pc + 1].longconst);
+      (*pos) += 2;
+      print_subexp (exp, pos, stream, PREC_SUFFIX);
+      fprintf_filtered (stream, ".%d", tem);
+      return;
+
     case STRUCTOP_MEMBER:
       print_subexp (exp, pos, stream, PREC_SUFFIX);
       fputs_filtered (".*", stream);
@@ -986,6 +993,16 @@ dump_subexp_body_standard (struct expression *exp,
 
 	fprintf_filtered (stream, "Element name: `%.*s'", len, elem_name);
 	elt = dump_subexp (exp, stream, elt + 3 + BYTES_TO_EXP_ELEM (len + 1));
+      }
+      break;
+    case STRUCTOP_ANONYMOUS:
+      {
+  int field_number;
+
+  field_number = longest_to_int (exp->elts[elt].longconst);
+
+  fprintf_filtered (stream, "Field number: %d", field_number);
+  elt = dump_subexp (exp, stream, elt + 2);
       }
       break;
     case OP_SCOPE:

--- a/gdb/parse.c
+++ b/gdb/parse.c
@@ -930,6 +930,7 @@ operator_length_standard (const struct expression *expr, int endpos,
     case BINOP_VAL:
     case UNOP_CAST:
     case UNOP_MEMVAL:
+    case STRUCTOP_ANONYMOUS:
       oplen = 3;
       args = 1;
       break;

--- a/gdb/rust-lang.c
+++ b/gdb/rust-lang.c
@@ -495,12 +495,16 @@ rust_val_print (struct type *type, const gdb_byte *valaddr, int embedded_offset,
 	struct value_print_options opts;
 
 	if (!is_tuple && TYPE_TAG_NAME (type))
-	  fprintf_filtered (stream, "%s ", TYPE_TAG_NAME (type));
+	  fprintf_filtered (stream, "%s", TYPE_TAG_NAME (type));
+
+	if (TYPE_NFIELDS (type) == 0 && !is_tuple) {
+	  break;
+	}
 
 	if (is_tuple || is_tuple_struct)
-	  fputs_filtered ("(", stream);
+	  fputs_filtered (" (", stream);
 	else
-	  fputs_filtered ("{", stream);
+	  fputs_filtered (" {", stream);
 
 	opts = *options;
 	opts.deref_ref = 0;
@@ -655,6 +659,10 @@ rust_print_type (struct type *type, const char *varstring,
 	  fputs_filtered (TYPE_TAG_NAME (type), stream);
 
 	is_tuple_struct = rust_tuple_struct_type_p (type);
+
+	if (TYPE_NFIELDS (type) == 0 && !rust_tuple_type_p (type)) {
+	  break;
+	}
 	fputs_filtered (is_tuple_struct ? " (\n" : " {\n", stream);
 
 	for (i = 0; i < TYPE_NFIELDS (type); ++i)

--- a/gdb/rust-lang.c
+++ b/gdb/rust-lang.c
@@ -1553,7 +1553,7 @@ not a tuple, tuple struct, or tuple-like variant"),
 
           variant_type = TYPE_FIELD_TYPE (type, disr.field_no);
 
-          if (rust_tuple_struct_type_p (variant_type)) {
+          if (rust_tuple_variant_type_p (variant_type)) {
             error(_("Attempting to access named field %s of tuple variant %s, \
 which has only anonymous fields"),
                   field_name, disr.name);

--- a/gdb/rust-lang.c
+++ b/gdb/rust-lang.c
@@ -35,7 +35,6 @@
 
 extern initialize_file_ftype _initialize_rust_language;
 
-
 /* Returns the last segment of a Rust path like foo::bar::baz.
    Will not handle cases where the last segment contains generics */
 
@@ -70,7 +69,59 @@ rust_crate_for_block (const struct block *block)
   return xstrndup (scope, len);
 }
 
-
+/* Information about the discriminant/variant of an enum */
+
+struct disr_info {
+  char* name; // needs to be freed
+  int field_no; // Field number in union. negative if error
+};
+
+/* Utility function to get discriminant info for a given value */
+static struct disr_info
+rust_get_disr_info (struct type *type, const gdb_byte *valaddr, int embedded_offset,
+                    CORE_ADDR address, const struct value *val) {
+
+  int i;
+  struct disr_info ret;
+  struct type *disr_type;
+  struct ui_file * temp_file;
+
+  struct value_print_options opts;
+
+  get_no_prettyformat_print_options (&opts);
+
+  ret.field_no = -1;
+
+  disr_type = TYPE_FIELD_TYPE (type, 0);
+
+  temp_file = mem_fileopen ();
+
+  // The first value of the first field (or any field) is the discriminant value
+  c_val_print (TYPE_FIELD_TYPE (disr_type, 0), valaddr,
+              embedded_offset + TYPE_FIELD_BITPOS (type, 0) / 8
+                              + TYPE_FIELD_BITPOS (disr_type, 0) / 8,
+              address, temp_file,
+              0, val, &opts);
+
+  ret.name = ui_file_xstrdup (temp_file, NULL);
+  ui_file_delete (temp_file);
+
+  for (i = 0; i < TYPE_NFIELDS (type); ++i) {
+
+    // Sadly, the discriminant value paths do not match the type field name paths
+    // (`core::option::Option::Some` vs `core::option::Some`)
+    // However, enum variant names are unique in the last path segment
+    // and the generics are not part of this path, so we can just compare those
+    // This is hackish and would be better fixed by improving rustc's
+    // metadata for enums
+    if(strcmp (rust_last_path_segment (ret.name),
+               rust_last_path_segment (TYPE_NAME (TYPE_FIELD_TYPE (type, i)))) == 0) {
+      ret.field_no = i;
+    }
+  }
+  return ret;
+
+}
 
 /* See rust-lang.h.  */
 
@@ -339,78 +390,47 @@ rust_val_print (struct type *type, const gdb_byte *valaddr, int embedded_offset,
       break;
     case TYPE_CODE_UNION:
     {
-      int i, j, nfields, first_field;
-      char* disr;
-      struct type *disr_type, *variant_type;
-      struct ui_file * temp_file;
+      int j, nfields, first_field;
+      struct type *variant_type;
+      struct disr_info disr;
       struct value_print_options opts;
 
       opts = *options;
       opts.deref_ref = 0;
 
-      opts = *options;
-      opts.deref_ref = 0;
-      disr_type = TYPE_FIELD_TYPE (type, 0);
+      disr = rust_get_disr_info(type, valaddr, embedded_offset, address, val);
 
-      temp_file = mem_fileopen ();
+      first_field = 1;
+      variant_type = TYPE_FIELD_TYPE (type, disr.field_no);
+      nfields = TYPE_NFIELDS (variant_type);
 
-      // The first value of the first field (or any field) is the discriminant value
-      c_val_print (TYPE_FIELD_TYPE (disr_type, 0), valaddr,
-                  embedded_offset + TYPE_FIELD_BITPOS (type, 0) / 8
-                                  + TYPE_FIELD_BITPOS (disr_type, 0) / 8,
-                  address, temp_file,
-      recurse, val, options);
-
-      disr = ui_file_xstrdup (temp_file, NULL);
-
-      ui_file_delete (temp_file);
-
-
-      for (i = 0; i < TYPE_NFIELDS (type); ++i) {
-
-        // Sadly, the discriminant value paths do not match the type field name paths
-        // (`core::option::Option::Some` vs `core::option::Some`)
-        // However, enum variant names are unique in the last path segment
-        // and the generics are not part of this path, so we can just compare those
-        // This is hackish and would be better fixed by improving rustc's
-        // metadata for enums
-        if(strcmp(rust_last_path_segment (disr),
-                  rust_last_path_segment (TYPE_NAME (TYPE_FIELD_TYPE (type, i)))) == 0) {
-
-            first_field = 1;
-            variant_type = TYPE_FIELD_TYPE (type, i);
-            nfields = TYPE_NFIELDS (variant_type);
-
-            if (nfields > 1) {
-              // In case of a non-nullary variant, we output `Foo(x,y,z)`
-              fprintf_filtered (stream, "%s(", disr);
-            } else {
-              // In case of a nullary variant like `None`, just output the name
-              fprintf_filtered (stream, "%s", disr);
-              break;
-            }
-
-            for (j = 1; j < TYPE_NFIELDS (variant_type); j++) {
-
-              if (!first_field) {
-                fputs_filtered (", ", stream);
-              }
-              first_field = 0;
-
-              val_print (TYPE_FIELD_TYPE (variant_type, j),
-                         valaddr,
-                         embedded_offset + TYPE_FIELD_BITPOS (type, i) / 8
-                                         + TYPE_FIELD_BITPOS (variant_type, j) / 8,
-                         address,
-                         stream, recurse + 1, val, &opts,
-                         current_language);
-            }
-
-            fputs_filtered (")", stream);
-            break;
-        }
+      if (nfields > 1) {
+        // In case of a non-nullary variant, we output `Foo(x,y,z)`
+        fprintf_filtered (stream, "%s(", disr.name);
+      } else {
+        // In case of a nullary variant like `None`, just output the name
+        fprintf_filtered (stream, "%s", disr.name);
+        break;
       }
-      free (disr);
+
+      for (j = 1; j < TYPE_NFIELDS (variant_type); j++) {
+
+        if (!first_field) {
+          fputs_filtered (", ", stream);
+        }
+        first_field = 0;
+
+        val_print (TYPE_FIELD_TYPE (variant_type, j),
+                   valaddr,
+                   embedded_offset + TYPE_FIELD_BITPOS (type, disr.field_no) / 8
+                                   + TYPE_FIELD_BITPOS (variant_type, j) / 8,
+                   address,
+                   stream, recurse + 1, val, &opts,
+                   current_language);
+      }
+
+      fputs_filtered (")", stream);
+      free (disr.name);
     }
       break;
     case TYPE_CODE_STRUCT:

--- a/gdb/std-operator.def
+++ b/gdb/std-operator.def
@@ -266,6 +266,9 @@ OP (OP_M2_STRING)		/* Modula-2 string constants */
 OP (STRUCTOP_STRUCT)
 OP (STRUCTOP_PTR)
 
+/* Anonymous field access, e.g. foo.3 . Used in Rust. */
+OP (STRUCTOP_ANONYMOUS)
+
 /* C++: OP_THIS is just a placeholder for the class instance variable.
    It just comes in a tight (OP_THIS, OP_THIS) pair.  */
 OP (OP_THIS)

--- a/gdb/testsuite/gdb.rust/simple.exp
+++ b/gdb/testsuite/gdb.rust/simple.exp
@@ -40,12 +40,9 @@ gdb_test "ptype b" " = \\\[i32; 0\\\]"
 gdb_test "print c" " = 99"
 gdb_test "ptype c" " = i32"
 
-gdb_test "print j" " = simple::Unit \\{\\}"
-gdb_test_sequence "ptype j" "" {
-    " = struct simple::Unit \\{"
-    "\\}"
-}
-gdb_test "print simple::Unit" " = simple::Unit \\{\\}"
+gdb_test "print j" " = simple::Unit"
+gdb_test "ptype j" " = struct simple::Unit"
+gdb_test "print simple::Unit" " = simple::Unit"
 
 gdb_test "print g" " = \\(u8 \\(\\*\\)\\\[6\\\]\\) $hex b\"hi bob\""
 gdb_test "ptype g" " = u8 \\(\\*\\)\\\[6\\\]"
@@ -98,7 +95,7 @@ gdb_test "print \"hello rust\"" \
 gdb_test "print 0..5" " = .*::ops::Range.* \\{start: 0, end: 5\\}"
 gdb_test "print ..5" " = .*::ops::RangeTo.* \\{end: 5\\}"
 gdb_test "print 5.." " = .*::ops::RangeFrom.* \\{start: 5\\}"
-gdb_test "print .." " = .*::ops::RangeFull \\{\\}"
+gdb_test "print .." " = .*::ops::RangeFull"
 
 
 proc test_one_slice {svar length base range} {

--- a/gdb/testsuite/gdb.rust/simple.exp
+++ b/gdb/testsuite/gdb.rust/simple.exp
@@ -87,13 +87,14 @@ gdb_test "print e" " = simple::MoreComplicated::Two\\(73\\)"
 gdb_test "print e2" \
          " = simple::MoreComplicated::Four\\{this: true, is: 8, a: 109 'm', struct_: 100, variant: 10\\}"
 
-gdb_test_sequence "ptype e" "" \
-    [list " = enum simple::MoreComplicated \\{" \
+gdb_test_sequence "ptype e" "" {
+    " = enum simple::MoreComplicated \\{" \
      "  One," \
      "  Two\\(i32\\)," \
      "  Three\\(simple::HiBob\\)," \
      "  Four\\{this: bool, is: u8, a: char, struct_: u64, variant: u32\\}," \
-     "\\}"]
+     "\\}"
+}
 
 gdb_test "print e.0" " = 73"
 gdb_test "print e.1" \

--- a/gdb/testsuite/gdb.rust/simple.exp
+++ b/gdb/testsuite/gdb.rust/simple.exp
@@ -83,6 +83,30 @@ gdb_test "print z.1" " = 8"
 gdb_test "print simple::ByeBob(0xff, 5)" \
     " = simple::ByeBob \\(255, 5\\)"
 
+gdb_test "print e" " = simple::MoreComplicated::Two\\(73\\)"
+gdb_test "print e2" \
+         " = simple::MoreComplicated::Four\\{this: true, is: 8, a: 109 'm', struct_: 100, variant: 10\\}"
+
+gdb_test_sequence "ptype e" "" \
+    [list " = enum simple::MoreComplicated \\{" \
+     "  One," \
+     "  Two\\(i32\\)," \
+     "  Three\\(simple::HiBob\\)," \
+     "  Four\\{this: bool, is: u8, a: char, struct_: u64, variant: u32\\}," \
+     "\\}"]
+
+gdb_test "print e.0" " = 73"
+gdb_test "print e.1" \
+         "Cannot access field 1 of variant simple::MoreComplicated::Two, there are only 1 fields"
+gdb_test "print e.foo" \
+         "Attempting to access named field foo of tuple variant simple::MoreComplicated::Two, which has only anonymous fields"
+
+gdb_test "print e2.variant" " = 10"
+gdb_test "print e2.notexist" \
+         "Could not find field notexist of struct variant simple::MoreComplicated::Four"
+gdb_test "print e2.0" \
+         "Variant simple::MoreComplicated::Four is not a tuple variant"
+
 gdb_test "print diff2(3, 7)" " = -4"
 gdb_test "print self::diff2(8, 9)" " = -1"
 gdb_test "print ::diff2(23, -23)" " = 46"

--- a/gdb/testsuite/gdb.rust/simple.rs
+++ b/gdb/testsuite/gdb.rust/simple.rs
@@ -34,7 +34,8 @@ enum Something {
 enum MoreComplicated {
     One,
     Two(i32),
-    Three(HiBob)
+    Three(HiBob),
+    Four{this: bool, is: u8, a: char, struct_: u64, variant: u32},
 }
 
 fn diff2(x: i32, y: i32) -> i32 {
@@ -51,6 +52,7 @@ fn main () {
     let d = c = 99;
 
     let e = MoreComplicated::Two(73);
+    let e2 = MoreComplicated::Four {this: true, is: 8, a: 'm', struct_: 100, variant: 10};
 
     let f = "hi bob";
     let g = b"hi bob";


### PR DESCRIPTION
This adds support for printing types and values of non-C-like enums, as well as providing the ability to access fields for both tuple-like and struct-like variants.

It additionally:
-  adds `STRUCTOP_ANONYMOUS` for anonymous field accesses (`foo.0`) instead of overloading `STRUCTOP_STRUCT` by calling the field `__0`.
- makes unit structs print without braces

<s>Still incomplete, needs error handling/sanity checks/tests, and perhaps support for struct variants. Ready for pre-review, though.</s>

Ready for review

Fixes #7 

r? @tromey 
